### PR TITLE
Move loggers to the top of their class

### DIFF
--- a/org.eclipse.jgit/src/org/eclipse/jgit/lib/RepositoryCache.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/lib/RepositoryCache.java
@@ -64,10 +64,10 @@ import org.slf4j.LoggerFactory;
 
 /** Cache of active {@link Repository} instances. */
 public class RepositoryCache {
-	private static final RepositoryCache cache = new RepositoryCache();
-
 	private final static Logger LOG = LoggerFactory
 			.getLogger(RepositoryCache.class);
+
+	private static final RepositoryCache cache = new RepositoryCache();
 
 	/**
 	 * Open an existing repository, reusing a cached instance if possible.

--- a/org.eclipse.jgit/src/org/eclipse/jgit/util/FS.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/util/FS.java
@@ -77,6 +77,8 @@ import org.slf4j.LoggerFactory;
 
 /** Abstraction to support various file system operations not in Java. */
 public abstract class FS {
+	private static final Logger LOG = LoggerFactory.getLogger(FS.class);
+
 	/**
 	 * This class creates FS instances. It will be overridden by a Java7 variant
 	 * if such can be detected in {@link #detect(Boolean)}.
@@ -157,8 +159,6 @@ public abstract class FS {
 			return rc;
 		}
 	}
-
-	private final static Logger LOG = LoggerFactory.getLogger(FS.class);
 
 	/** The auto-detected implementation selected for this operating system and JRE. */
 	public static final FS DETECTED = detect();


### PR DESCRIPTION
There is a possibility of hitting NPE on a logger if it is not the first
statically initialized member. For example, if another static
initializer creates an instance of its class and the logger is used
from the constructor.

Change-Id: I51fa855a8883c107f2e4ef5ac039dc12a571a7ae